### PR TITLE
refactor for nbb 4.15.0

### DIFF
--- a/library.js
+++ b/library.js
@@ -7,16 +7,18 @@ const {
 } = require('@dice-roller/rpg-dice-roller');
 
 
-const nconf = require.main.require('nconf');
-const { events, getTopicField } = require.main.require('./src/topics');
-const { getPostData } = require.main.require('./src/posts');
-const { addSystemMessage } = require.main.require('./src/messaging');
-const { emitToUids } = require.main.require('./src/socket.io/helpers');
-const { getUidsFromSet } = require.main.require('./src/user');
-const { filterUids } = require.main.require('./src/privileges/categories');
-const helpers = require.main.require('./src/helpers');
-const utils = require.main.require('./src/utils');
-const translator = require.main.require('./src/translator');
+const nconf = nodebb.require('nconf');
+const { events, getTopicField } = nodebb.require('./src/topics');
+const { getPostData } = nodebb.require('./src/posts');
+
+const { emitToUids } = nodebb.require('./src/socket.io/helpers');
+const { getUidsFromSet } = nodebb.require('./src/user');
+const { filterUids } = nodebb.require('./src/privileges/categories');
+const helpers = nodebb.require('./src/helpers');
+const utils = nodebb.require('./src/utils');
+const tx = nodebb.require('./src/translator');
+const messaging = nodebb.require('./src/messaging');
+const user = nodebb.require('./src/user');
 
 const relative_path = nconf.get('relative_path');
 
@@ -87,12 +89,12 @@ function renderTimeago(timestamp) {
 	return `<span class="timeago timeline-text" title="${timestamp}"></span>`;
 }
 
-async function translateDiceEvent(event) {
+async function translateDiceEvent(event, language) {
 	const diceText = event.text === undefined ?
 		createText(event.total, JSON.parse(event.rolls), JSON.parse(event.diceUsed), event.parsedNotation) :
 		event.text;
 	const text = `${diceText} ${renderUser(event.user)} ${renderTimeago(event.timestampISO)}`;
-	return utils.decodeHTMLEntities(await translator.translate(text));
+	return utils.decodeHTMLEntities(await tx.translate(text, language));
 }
 
 function createText(total, rolls, diceUsed, notation) {
@@ -303,7 +305,18 @@ plugin.onSentMessage = async function ({ message, data }) {
 	const results = await parseChatCommands(message);
 
 	for (const result of results ?? []) {
-		addSystemMessage(`dice-ignore]]${result} [[modules:chat.system.dice-for`, data.uid, data.roomId);
+		// not using core addSystemMessage because it doesn't allow for custom content
+		const displayname = await user.getNotificationDisplayname(data.uid);
+		const message = await messaging.addMessage({
+			type: 'dice-roll',
+			// core runs tx.translate on content if system is set to 1
+			content: `${result} ${displayname}`,
+			uid: data.uid,
+			roomId: data.roomId,
+			system: 1,
+			timestamp: Date.now(),
+		});
+		messaging.notifyUsersInRoom(data.uid, data.roomId, message);
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	},
 	"readmeFilename": "README.md",
 	"nbbpm": {
-		"compatibility": "^3.0.0"
+		"compatibility": "^4.15.0"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "17.8.1",

--- a/static/languages/en-GB/modules.json
+++ b/static/languages/en-GB/modules.json
@@ -1,4 +1,0 @@
-{
-	"chat.system.dice-ignore": "​",
-	"chat.system.dice-for": "%1"
-}

--- a/test/index.js
+++ b/test/index.js
@@ -22,9 +22,9 @@
 const assert = require('assert');
 
 
-const topics = require.main.require('./src/topics');
-const categories = require.main.require('./src/categories');
-const user = require.main.require('./src/user');
+const topics = nodebb.require('./src/topics');
+const categories = nodebb.require('./src/categories');
+const user = nodebb.require('./src/user');
 
 
 describe('nodebb-plugin-ws-dice', () => {

--- a/upgrades/dice_remove_unnecessary_span.js
+++ b/upgrades/dice_remove_unnecessary_span.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { scan, setObjectBulk, getObjects } = require.main.require('./src/database');
+const { scan, setObjectBulk, getObjects } = nodebb.require('./src/database');
 async function removeSpan() {
 	const migrationRegex = /^<span class="dice-event-text">(?<text>.+)<\/span>$/;
 	const keys = await scan({ match: 'topicEvent:*' });


### PR DESCRIPTION
use nodebb.require instead of require.main.require 

use language passed to tranlateDiceEvent to translate 

get rid of dice-ignore hack, use addMessage directly, on 4.15.0 core runs tx.translate on content of system messages. 
4.15.0 removes the translator.translate() pass on the entire page, so hacks like dice-ignore]] [[another:translation no longer work.